### PR TITLE
Refactor: Use Flow for Store Data Retrieval and Update Logic

### DIFF
--- a/common/src/main/java/com/zaed/common/data/repository/StoreRepository.kt
+++ b/common/src/main/java/com/zaed/common/data/repository/StoreRepository.kt
@@ -5,9 +5,10 @@ import com.zaed.common.data.model.store.request.AddStoreRequest
 import com.zaed.common.data.model.store.request.DeleteStoreRequest
 import com.zaed.common.data.model.store.request.FetchStoreByIdRequest
 import com.zaed.common.data.model.store.request.UpdateStoreRequest
+import kotlinx.coroutines.flow.Flow
 
 interface StoreRepository {
-    suspend fun getStores(): Result<List<Store>>
+    fun getStores(): Flow<Result<List<Store>>>
     suspend fun addStore(request: AddStoreRequest): Result<Unit>
     suspend fun updateStore(request: UpdateStoreRequest): Result<Unit>
     suspend fun deleteStore(request: DeleteStoreRequest): Result<Unit>

--- a/common/src/main/java/com/zaed/common/data/repository/StoreRepositoryImpl.kt
+++ b/common/src/main/java/com/zaed/common/data/repository/StoreRepositoryImpl.kt
@@ -6,11 +6,12 @@ import com.zaed.common.data.model.store.request.DeleteStoreRequest
 import com.zaed.common.data.model.store.request.FetchStoreByIdRequest
 import com.zaed.common.data.model.store.request.UpdateStoreRequest
 import com.zaed.common.data.source.remote.StoreRemoteDataSource
+import kotlinx.coroutines.flow.Flow
 
 class StoreRepositoryImpl(
     private val remoteDataSource: StoreRemoteDataSource
 ) : StoreRepository {
-    override suspend fun getStores(): Result<List<Store>> {
+    override fun getStores(): Flow<Result<List<Store>>> {
         return remoteDataSource.getStores()
     }
 

--- a/common/src/main/java/com/zaed/common/data/source/remote/StoreRemoteDataSource.kt
+++ b/common/src/main/java/com/zaed/common/data/source/remote/StoreRemoteDataSource.kt
@@ -5,9 +5,10 @@ import com.zaed.common.data.model.store.request.AddStoreRequest
 import com.zaed.common.data.model.store.request.DeleteStoreRequest
 import com.zaed.common.data.model.store.request.FetchStoreByIdRequest
 import com.zaed.common.data.model.store.request.UpdateStoreRequest
+import kotlinx.coroutines.flow.Flow
 
 interface StoreRemoteDataSource {
-    suspend fun getStores(): Result<List<Store>>
+    fun getStores(): Flow<Result<List<Store>>>
     suspend fun addStore(request: AddStoreRequest): Result<Unit>
     suspend fun updateStore(request: UpdateStoreRequest): Result<Unit>
     suspend fun deleteStore(request: DeleteStoreRequest): Result<Unit>

--- a/common/src/main/java/com/zaed/common/data/source/remote/StoreRemoteDataSourceImpl.kt
+++ b/common/src/main/java/com/zaed/common/data/source/remote/StoreRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.zaed.common.data.source.remote
 
+import com.google.android.gms.tasks.Tasks.await
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.firestore.FirebaseFirestore
 import com.zaed.common.data.model.store.Store
@@ -7,6 +8,8 @@ import com.zaed.common.data.model.store.request.AddStoreRequest
 import com.zaed.common.data.model.store.request.DeleteStoreRequest
 import com.zaed.common.data.model.store.request.FetchStoreByIdRequest
 import com.zaed.common.data.model.store.request.UpdateStoreRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
 class StoreRemoteDataSourceImpl(
@@ -15,14 +18,22 @@ class StoreRemoteDataSourceImpl(
 ) : StoreRemoteDataSource {
     private val STORE_COLLECTION = "stores"
     private val storesCollection = firestore.collection(STORE_COLLECTION)
-    override suspend fun getStores(): Result<List<Store>> {
-        return try {
-            val snapshot = storesCollection.get().await()
-            val stores = snapshot.toObjects(Store::class.java)
-            Result.success(stores)
+    override fun getStores(): Flow<Result<List<Store>>> = callbackFlow{
+        try {
+            storesCollection.addSnapshotListener{ snapshot, e ->
+                if(e != null){
+                    crashlytics.recordException(e)
+                    trySend(Result.failure(e))
+                    return@addSnapshotListener
+                }
+                if(snapshot != null){
+                    val stores = snapshot.toObjects(Store::class.java)
+                    trySend(Result.success(stores))
+                }
+            }
         }catch (e: Exception){
             crashlytics.recordException(e)
-            Result.failure(e)
+            trySend(Result.failure(e))
         }
     }
 

--- a/common/src/main/java/com/zaed/common/domain/store/GetStoresUseCase.kt
+++ b/common/src/main/java/com/zaed/common/domain/store/GetStoresUseCase.kt
@@ -6,7 +6,5 @@ import com.zaed.common.data.repository.StoreRepository
 class GetStoresUseCase(
     private val repository: StoreRepository
 ){
-    suspend operator fun invoke(): Result<List<Store>> {
-        return repository.getStores()
-    }
+    operator fun invoke() =  repository.getStores()
 }

--- a/common/src/main/java/com/zaed/common/ui/auth/signup/SignUpViewModel.kt
+++ b/common/src/main/java/com/zaed/common/ui/auth/signup/SignUpViewModel.kt
@@ -29,15 +29,17 @@ class SignUpViewModel(
 
     private fun getStores() {
         viewModelScope.launch(Dispatchers.IO) {
-            getStoresUseCase().onSuccess { data ->
-                stores.update {
-                    it.copy(
-                        stores = data
-                    )
-                }
-            }.onFailure { error ->
-                _uiState.update {
-                    it.copy(errorMessage = Exception(error.message))
+            getStoresUseCase().collect { result ->
+                result.onSuccess { data ->
+                    stores.update {
+                        it.copy(
+                            stores = data
+                        )
+                    }
+                }.onFailure { error ->
+                    _uiState.update {
+                        it.copy(errorMessage = Exception(error.message))
+                    }
                 }
             }
         }

--- a/manager/src/main/java/com/zaed/manager/ui/stores/StoresViewModel.kt
+++ b/manager/src/main/java/com/zaed/manager/ui/stores/StoresViewModel.kt
@@ -31,10 +31,12 @@ class StoresViewModel(
     }
     private fun fetchStores(){
         viewModelScope.launch (Dispatchers.IO){
-            getStoresUseCase().onSuccess {  data ->
-                _uiState.update { oldState -> oldState.copy(stores = data) }
-            }.onFailure {
-                Log.e(TAG, "fetchStores: ", )
+            getStoresUseCase().collect { result ->
+                result.onSuccess { data ->
+                    _uiState.update { oldState -> oldState.copy(stores = data) }
+                }.onFailure {
+                    Log.e(TAG, "fetchStores: ",)
+                }
             }
         }
     }


### PR DESCRIPTION
- Modified `StoreRepository`, `StoreRemoteDataSource`, and `StoreRemoteDataSourceImpl` to use `Flow` for retrieving store data.
- Updated `GetStoresUseCase` to return a `Flow` of `Result<List<Store>>`.
- Changed `StoresViewModel` and `SignUpViewModel` to collect data from the `Flow` returned by `GetStoresUseCase`.
- Modified logic to listen to changes in the collection.